### PR TITLE
Fix ansible and ansible-lint warnings.

### DIFF
--- a/tasks/global-setup.yml
+++ b/tasks/global-setup.yml
@@ -13,5 +13,4 @@
     regexp: ^check_interval =
     line: check_interval = {{ gitlab_runner_check_interval }}
     state: present
-  when: "{{ gitlab_runner_check_interval }}"
-  
+  when: gitlab_runner_check_interval

--- a/tasks/install-debian.yml
+++ b/tasks/install-debian.yml
@@ -35,3 +35,4 @@
     name: gitlab-ci-multi-runner
     state: latest
     update_cache: yes
+  tags: skip_ansible_lint

--- a/tasks/install-redhat.yml
+++ b/tasks/install-redhat.yml
@@ -27,3 +27,4 @@
     name: gitlab-ci-multi-runner
     state: latest
     update_cache: yes
+  tags: skip_ansible_lint

--- a/tasks/register-runner.yml
+++ b/tasks/register-runner.yml
@@ -19,7 +19,7 @@
     --ssh-port '{{gitlab_runner_ssh_port}}'
     --ssh-password '{{gitlab_runner_ssh_password}}'
     --ssh-identity-file '{{gitlab_runner_ssh_identity_file}}'
-  when: gitlab_runner_registration_token != '' and configured_runners.stderr.find('\n{{ gitlab_runner_description }}') == -1
+  when: gitlab_runner_registration_token != '' and configured_runners.stderr.find('\n%s' % gitlab_runner_description) == -1
 
 - name: Register multiple runner to GitLab
   command: gitlab-runner register >


### PR DESCRIPTION
Hello,

Your fork-of-a-fork seems to be the most up to date (see my summary of the fork situation for this project: https://github.com/haroldb/ansible-gitlab-runner/issues/7).

This fixes a couple ansible warnings:
```
 [WARNING]: when statements should not include jinja2 templating delimiters
such as {{ }} or {% %}. Found: gitlab_runner_registration_token != '' and
configured_runners.stderr.find('\n{{ gitlab_runner_description }}') == -1
```

and disables a couple [ansible-lint](https://github.com/willthames/ansible-lint) warnings:
```
[ANSIBLE0010] Package installs should not use latest
```

I tested the affected plays by hand to verify they still work.

I figured I'd PR the fixes back to you so the world has one fewer ansible-gitlab-runner fork to worry about :).