### PR TITLE
Fix Debian repo URL

### DIFF
--- a/tasks/install-debian.yml
+++ b/tasks/install-debian.yml
@@ -26,7 +26,7 @@
 
 - name: Add GitLab Runner apt repo
   apt_repository:
-    repo: 'deb https://packages.gitlab.com/runner/gitlab-ci-multi-runner/{{ ansible_distribution | lower }}/ {{ ansible_distribution_major_version }} main'
+    repo: 'deb https://packages.gitlab.com/runner/gitlab-ci-multi-runner/{{ ansible_distribution | lower }}/ {{ ansible_distribution_release }} main'
     state: present
   when: (ansible_distribution == "Debian")
 


### PR DESCRIPTION
The URL for the Gitlab APT repository is wrong. This PR fixes that. Tested against Debian Jessie.