### PR TITLE
Fix Debian repo URL

### DIFF
--- a/tasks/install-debian.yml
+++ b/tasks/install-debian.yml
@@ -26,7 +26,7 @@
 
 - name: Add GitLab Runner apt repo
   apt_repository:
-    repo: 'deb https://packages.gitlab.com/runner/gitlab-ci-multi-runner/{{ ansible_distribution | lower }}/ {{ ansible_distribution_major_version }} main'
+    repo: 'deb https://packages.gitlab.com/runner/gitlab-ci-multi-runner/{{ ansible_distribution | lower }}/ {{ ansible_distribution_release }} main'
     state: present
   when: (ansible_distribution == "Debian")
 


### PR DESCRIPTION
Applying the role fails on Debian Jessie, because the Gitlab APT repository URL is wrong. This should fix it. I only tested it against Jessie.