### PR TITLE
Bugfix: generate volumes config line correctly

### DIFF
--- a/tasks/register-runner.yml
+++ b/tasks/register-runner.yml
@@ -14,7 +14,7 @@
     --tag-list '{{ gitlab_runner_tags | join(",") }}'
     --executor '{{ gitlab_runner_executor }}'
     --docker-image '{{ gitlab_runner_docker_image }}'
-    --docker-volumes [ "{{ gitlab_runner_docker_volumes | join('", "') }}" ]
+    --docker-volumes "{{ gitlab_runner_docker_volumes | join('", "') }}"
     --ssh-user '{{gitlab_runner_ssh_user}}'
     --ssh-host '{{gitlab_runner_ssh_host}}'
     --ssh-port '{{gitlab_runner_ssh_port}}'


### PR DESCRIPTION
I think this syntax is the correct one. With the current master, my CI builds fail to run, with this in the runner log:

```
rm: can't remove '/builds/awesto/hypocaust/[': Resource busy
```
